### PR TITLE
Added IMAP.AccessAsUser permission

### DIFF
--- a/public/rogueapps.json
+++ b/public/rogueapps.json
@@ -14,6 +14,11 @@
       },
       {
         "resource": "Microsoft Graph",
+        "permission": "IMAP.AccessAsUser.All",
+        "type": "Delegated"
+      },
+      {
+        "resource": "Microsoft Graph",
         "permission": "offline_access",
         "type": "Delegated"
       },


### PR DESCRIPTION
Based on a recent attack we observed, adding the permission IMAP.AccessAsUser.all to this page.

![image](https://github.com/user-attachments/assets/a395701a-ec8b-418a-b82a-03cbdaa3cc84)
